### PR TITLE
Better support Ubuntu and Debian

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,8 @@ class openvpn (
   $client2client = false,
   $package_name  = $::openvpn::params::package_name,
   $service_name  = $::openvpn::params::service_name,
+  $service_user  = $::openvpn::params::service_user,
+  $service_group = $::openvpn::params::service_group,
 ) inherits ::openvpn::params {
 
   validate_array($routes)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,12 +4,12 @@
 # It sets variables according to platform.
 #
 class openvpn::params {
-  $service_username = 'nobody'
+  $service_user = 'nobody'
   case $::osfamily {
     'Debian': {
       $package_name = 'openvpn'
       $service_name = 'openvpn'
-      $service_groupname = 'nogroup'
+      $service_group = 'nogroup'
       case $::operatingsystem {
         'Debian': {
           case $::operatingsystemmajrelease {
@@ -28,7 +28,7 @@ class openvpn::params {
     }
     'RedHat', 'Amazon': {
       $package_name = 'openvpn'
-      $service_groupname = 'nobody'
+      $service_group = 'nobody'
       case $::operatingsystemmajrelease {
         '7': {
           $service_name = 'openvpn@openvpn'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,10 +4,12 @@
 # It sets variables according to platform.
 #
 class openvpn::params {
+  $service_username = 'nobody'
   case $::osfamily {
     'Debian': {
       $package_name = 'openvpn'
       $service_name = 'openvpn'
+      $service_groupname = 'nogroup'
       case $::operatingsystem {
         'Debian': {
           case $::operatingsystemmajrelease {
@@ -20,12 +22,13 @@ class openvpn::params {
           }
         }
         'Ubuntu': {
-          $service_name = 'upstart'
+          $service_provider = 'upstart'
         }
       }
     }
     'RedHat', 'Amazon': {
       $package_name = 'openvpn'
+      $service_groupname = 'nobody'
       case $::operatingsystemmajrelease {
         '7': {
           $service_name = 'openvpn@openvpn'

--- a/templates/openvpn.conf.erb
+++ b/templates/openvpn.conf.erb
@@ -30,6 +30,6 @@ route <%= route %>
 <% end -%>
 persist-key
 persist-tun
-user nobody
-group nobody
+user <%= scope.lookupvar('openvpn::service_user') %>
+group <%= scope.lookupvar('openvpn::service_group') %> 
 


### PR DESCRIPTION
Debian-based distros don't have a UNIX `nobody` group instead defaulting to `nogroup`. OpenVPN config previously hard-coded `group nobody` and hence failed on Ubuntu.
