### PR TITLE
Auto-restart openvpn if we are using a systemd based OS

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,4 +12,13 @@ class openvpn::service {
     hasstatus  => true,
     hasrestart => true,
   }
+
+  if $::openvpn::params::service_provider == 'systemd' {
+    augeas { 'auto-restart openvpn':
+      lens    => 'Systemd.lns',
+      incl    => '/lib/systemd/system/openvpn@.service',
+      changes => 'set /files/lib/systemd/system/openvpn@.service/Service/Restart/value on-failure',
+      notify  => Service[$::openvpn::service_name],
+    }
+  }
 }


### PR DESCRIPTION
It's a little chunky - aimed at CentOS 7 for osaka bastions. Should work OK on Debian / newer Ubuntu, too.
